### PR TITLE
fix: correct name for the devpod flatpak

### DIFF
--- a/dx_flatpaks/flatpaks
+++ b/dx_flatpaks/flatpaks
@@ -1,4 +1,4 @@
 app/io.podman_desktop.PodmanDesktop/x86_64/stable
 app/io.github.getnf.embellish/x86_64/stable
 app/me.iepure.devtoolbox/x86_64/stable
-app/sh.loft.Devpod/x86_64/stable
+app/sh.loft.devpod/x86_64/stable


### PR DESCRIPTION
noticed this on Aurora that the install-system-flatpak ujust script breaks because the devpod flatpak name had a capital D instead a lowercase one.

